### PR TITLE
create ScrollableModalBottomSheet Class

### DIFF
--- a/example/ios/Flutter/Debug.xcconfig
+++ b/example/ios/Flutter/Debug.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Flutter/Release.xcconfig
+++ b/example/ios/Flutter/Release.xcconfig
@@ -1,1 +1,2 @@
+#include? "Pods/Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"
 #include "Generated.xcconfig"

--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		97C146FC1CF9000F007C117D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FA1CF9000F007C117D /* Main.storyboard */; };
 		97C146FE1CF9000F007C117D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FD1CF9000F007C117D /* Assets.xcassets */; };
 		97C147011CF9000F007C117D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 97C146FF1CF9000F007C117D /* LaunchScreen.storyboard */; };
+		CDE54BAFD0EC42B1A2EDD6E9 /* Pods_Runner.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 6D4D25DA825CE4EFFBC9BBF1 /* Pods_Runner.framework */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXCopyFilesBuildPhase section */
@@ -31,7 +32,11 @@
 /* Begin PBXFileReference section */
 		1498D2321E8E86230040F4C2 /* GeneratedPluginRegistrant.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = GeneratedPluginRegistrant.h; sourceTree = "<group>"; };
 		1498D2331E8E89220040F4C2 /* GeneratedPluginRegistrant.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = GeneratedPluginRegistrant.m; sourceTree = "<group>"; };
+		2D14A64270E207D2D265744C /* Pods-Runner.profile.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.profile.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.profile.xcconfig"; sourceTree = "<group>"; };
 		3B3967151E833CAA004F5970 /* AppFrameworkInfo.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = AppFrameworkInfo.plist; path = Flutter/AppFrameworkInfo.plist; sourceTree = "<group>"; };
+		4AB8B3251E498BC2DAA93DFA /* Pods-Runner.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.release.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.release.xcconfig"; sourceTree = "<group>"; };
+		5E7CAA7148F659B289E4083B /* Pods-Runner.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-Runner.debug.xcconfig"; path = "Target Support Files/Pods-Runner/Pods-Runner.debug.xcconfig"; sourceTree = "<group>"; };
+		6D4D25DA825CE4EFFBC9BBF1 /* Pods_Runner.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_Runner.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		74858FAD1ED2DC5600515810 /* Runner-Bridging-Header.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = "Runner-Bridging-Header.h"; sourceTree = "<group>"; };
 		74858FAE1ED2DC5600515810 /* AppDelegate.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
 		7AFA3C8E1D35360C0083082E /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; name = Release.xcconfig; path = Flutter/Release.xcconfig; sourceTree = "<group>"; };
@@ -49,12 +54,32 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				CDE54BAFD0EC42B1A2EDD6E9 /* Pods_Runner.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
 /* End PBXFrameworksBuildPhase section */
 
 /* Begin PBXGroup section */
+		21ACC8010336457C3362B48E /* Frameworks */ = {
+			isa = PBXGroup;
+			children = (
+				6D4D25DA825CE4EFFBC9BBF1 /* Pods_Runner.framework */,
+			);
+			name = Frameworks;
+			sourceTree = "<group>";
+		};
+		59FBE06668D3E588AC6322DE /* Pods */ = {
+			isa = PBXGroup;
+			children = (
+				5E7CAA7148F659B289E4083B /* Pods-Runner.debug.xcconfig */,
+				4AB8B3251E498BC2DAA93DFA /* Pods-Runner.release.xcconfig */,
+				2D14A64270E207D2D265744C /* Pods-Runner.profile.xcconfig */,
+			);
+			name = Pods;
+			path = Pods;
+			sourceTree = "<group>";
+		};
 		9740EEB11CF90186004384FC /* Flutter */ = {
 			isa = PBXGroup;
 			children = (
@@ -72,6 +97,8 @@
 				9740EEB11CF90186004384FC /* Flutter */,
 				97C146F01CF9000F007C117D /* Runner */,
 				97C146EF1CF9000F007C117D /* Products */,
+				59FBE06668D3E588AC6322DE /* Pods */,
+				21ACC8010336457C3362B48E /* Frameworks */,
 			);
 			sourceTree = "<group>";
 		};
@@ -105,12 +132,14 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 97C147051CF9000F007C117D /* Build configuration list for PBXNativeTarget "Runner" */;
 			buildPhases = (
+				5D61690D5AB745F6A0CB3F01 /* [CP] Check Pods Manifest.lock */,
 				9740EEB61CF901F6004384FC /* Run Script */,
 				97C146EA1CF9000F007C117D /* Sources */,
 				97C146EB1CF9000F007C117D /* Frameworks */,
 				97C146EC1CF9000F007C117D /* Resources */,
 				9705A1C41CF9048500538489 /* Embed Frameworks */,
 				3B06AD1E1E4923F5004D2608 /* Thin Binary */,
+				E59004079DF392AE26E1EE97 /* [CP] Embed Pods Frameworks */,
 			);
 			buildRules = (
 			);
@@ -183,6 +212,28 @@
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" embed_and_thin";
 		};
+		5D61690D5AB745F6A0CB3F01 /* [CP] Check Pods Manifest.lock */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+				"${PODS_PODFILE_DIR_PATH}/Podfile.lock",
+				"${PODS_ROOT}/Manifest.lock",
+			);
+			name = "[CP] Check Pods Manifest.lock";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+				"$(DERIVED_FILE_DIR)/Pods-Runner-checkManifestLockResult.txt",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "diff \"${PODS_PODFILE_DIR_PATH}/Podfile.lock\" \"${PODS_ROOT}/Manifest.lock\" > /dev/null\nif [ $? != 0 ] ; then\n    # print error to STDERR\n    echo \"error: The sandbox is not in sync with the Podfile.lock. Run 'pod install' or update your CocoaPods installation.\" >&2\n    exit 1\nfi\n# This output is used by Xcode 'outputs' to avoid re-running this script phase.\necho \"SUCCESS\" > \"${SCRIPT_OUTPUT_FILE_0}\"\n";
+			showEnvVarsInLog = 0;
+		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
 			buildActionMask = 2147483647;
@@ -196,6 +247,23 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "/bin/sh \"$FLUTTER_ROOT/packages/flutter_tools/bin/xcode_backend.sh\" build";
+		};
+		E59004079DF392AE26E1EE97 /* [CP] Embed Pods Frameworks */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-input-files.xcfilelist",
+			);
+			name = "[CP] Embed Pods Frameworks";
+			outputFileListPaths = (
+				"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks-${CONFIGURATION}-output-files.xcfilelist",
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "\"${PODS_ROOT}/Target Support Files/Pods-Runner/Pods-Runner-frameworks.sh\"\n";
+			showEnvVarsInLog = 0;
 		};
 /* End PBXShellScriptBuildPhase section */
 

--- a/example/ios/Runner.xcworkspace/contents.xcworkspacedata
+++ b/example/ios/Runner.xcworkspace/contents.xcworkspacedata
@@ -4,4 +4,7 @@
    <FileRef
       location = "group:Runner.xcodeproj">
    </FileRef>
+   <FileRef
+      location = "group:Pods/Pods.xcodeproj">
+   </FileRef>
 </Workspace>

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -43,23 +43,24 @@ class _MyHomePageState extends State<MyHomePage> {
         child: TextButton(
           child: const Text("display showScrollableModalWebView"),
           onPressed: () => showScrollableModalWebView(
-            context: context,
-            header: Container(
-              height: 30,
-              decoration: const BoxDecoration(
-                color: Colors.blue,
+              context: context,
+              header: Container(
+                height: 30,
+                decoration: const BoxDecoration(
+                  borderRadius:
+                      BorderRadius.vertical(top: Radius.circular(10.0)),
+                  color: Colors.blue,
+                ),
+                child: const Center(
+                  child: Text('ScrollableModalBottomSheet'),
+                ),
               ),
-              child: const Center(
-                child: Text('ScrollableModalBottomSheet'),
-              ),
-            ),
-            headerColor: Colors.blue,
-            controller: controller,
-            initialChildSize: 1.0,
-            url: 'https://flutter.dev/',
-            borderRadius:
-                const BorderRadius.vertical(top: Radius.circular(10.0)),
-          ),
+              controller: controller,
+              initialChildSize: 1.0,
+              url: 'https://flutter.dev/',
+              shape: const RoundedRectangleBorder(
+                  borderRadius:
+                      BorderRadius.vertical(top: Radius.circular(10.0)))),
         ),
       ),
     );

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -45,21 +45,20 @@ class _MyHomePageState extends State<MyHomePage> {
           onPressed: () => showScrollableModalWebView(
             context: context,
             header: Container(
-              height: 50,
+              height: 30,
               decoration: const BoxDecoration(
-                borderRadius: BorderRadius.vertical(top: Radius.circular(10.0)),
                 color: Colors.blue,
               ),
               child: const Center(
                 child: Text('ScrollableModalBottomSheet'),
               ),
             ),
+            headerColor: Colors.blue,
             controller: controller,
-            initialChildSize: 0.85,
+            initialChildSize: 1.0,
             url: 'https://flutter.dev/',
-            shape: RoundedRectangleBorder(
-              borderRadius: BorderRadius.circular(10.0),
-            ),
+            borderRadius:
+                const BorderRadius.vertical(top: Radius.circular(10.0)),
           ),
         ),
       ),

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -44,7 +44,18 @@ class _MyHomePageState extends State<MyHomePage> {
           child: const Text("display showScrollableModalWebView"),
           onPressed: () => showScrollableModalWebView(
             context: context,
+            header: Container(
+              height: 50,
+              decoration: const BoxDecoration(
+                borderRadius: BorderRadius.vertical(top: Radius.circular(10.0)),
+                color: Colors.blue,
+              ),
+              child: const Center(
+                child: Text('ScrollableModalBottomSheet'),
+              ),
+            ),
             controller: controller,
+            initialChildSize: 0.85,
             url: 'https://flutter.dev/',
             shape: RoundedRectangleBorder(
               borderRadius: BorderRadius.circular(10.0),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -102,6 +102,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.8.2"
+  plugin_platform_interface:
+    dependency: transitive
+    description:
+      name: plugin_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.3"
   scrollable_modal_webview:
     dependency: "direct main"
     description:
@@ -163,6 +170,34 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.2"
+  webview_flutter:
+    dependency: "direct main"
+    description:
+      name: webview_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "4.0.2"
+  webview_flutter_android:
+    dependency: transitive
+    description:
+      name: webview_flutter_android
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.2.4"
+  webview_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: webview_flutter_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.1"
+  webview_flutter_wkwebview:
+    dependency: transitive
+    description:
+      name: webview_flutter_wkwebview
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "3.0.5"
 sdks:
   dart: ">=2.18.0 <3.0.0"
   flutter: ">=3.0.0"

--- a/lib/scrollable_modal_webview.dart
+++ b/lib/scrollable_modal_webview.dart
@@ -13,8 +13,7 @@ void showScrollableModalWebView({
   Widget? header,
   bool scrollable = true,
   double initialChildSize = 1.0,
-  BorderRadiusGeometry? borderRadius,
-  Color? headerColor,
+  ShapeBorder? shape,
 }) {
   if (!(Platform.isIOS || Platform.isAndroid)) {
     throw Exception('This OS is not supported');
@@ -22,17 +21,13 @@ void showScrollableModalWebView({
   showModalBottomSheet(
     context: context,
     isScrollControlled: true,
-    shape: RoundedRectangleBorder(
-        borderRadius: borderRadius ??
-            const BorderRadius.vertical(top: Radius.circular(0))),
+    shape: shape,
     builder: (BuildContext context) => ScrollableModalBottomSheet(
       controller: controller,
       initialChildSize: initialChildSize,
       scrollable: scrollable,
       url: url,
       header: header,
-      headerColor: headerColor,
-      borderRadius: borderRadius,
     ),
   );
 }
@@ -43,18 +38,14 @@ class ScrollableModalBottomSheet extends StatelessWidget {
   final double initialChildSize;
   final bool scrollable;
   final String url;
-  final Color? headerColor;
-  final BorderRadiusGeometry? borderRadius;
-  const ScrollableModalBottomSheet(
-      {Key? key,
-      required this.controller,
-      this.header,
-      required this.initialChildSize,
-      required this.scrollable,
-      required this.url,
-      this.headerColor,
-      this.borderRadius})
-      : super(key: key);
+  const ScrollableModalBottomSheet({
+    Key? key,
+    required this.controller,
+    this.header,
+    required this.initialChildSize,
+    required this.scrollable,
+    required this.url,
+  }) : super(key: key);
   @override
   Widget build(BuildContext context) {
     return DraggableScrollableSheet(
@@ -63,16 +54,7 @@ class ScrollableModalBottomSheet extends StatelessWidget {
         builder: (context, scrollController) {
           return Column(
             children: [
-              if (header != null) ...{
-                Container(
-                  decoration: BoxDecoration(
-                    borderRadius: borderRadius,
-                    color: headerColor,
-                  ),
-                  height: MediaQuery.of(context).padding.bottom,
-                ),
-                header!,
-              },
+              if (header != null) header!,
               Expanded(
                   child: SingleChildScrollView(
                 physics:

--- a/lib/scrollable_modal_webview.dart
+++ b/lib/scrollable_modal_webview.dart
@@ -13,7 +13,8 @@ void showScrollableModalWebView({
   Widget? header,
   bool scrollable = true,
   double initialChildSize = 1.0,
-  ShapeBorder? shape,
+  BorderRadiusGeometry? borderRadius,
+  Color? headerColor,
 }) {
   if (!(Platform.isIOS || Platform.isAndroid)) {
     throw Exception('This OS is not supported');
@@ -21,13 +22,17 @@ void showScrollableModalWebView({
   showModalBottomSheet(
     context: context,
     isScrollControlled: true,
-    shape: shape,
+    shape: RoundedRectangleBorder(
+        borderRadius: borderRadius ??
+            const BorderRadius.vertical(top: Radius.circular(0))),
     builder: (BuildContext context) => ScrollableModalBottomSheet(
       controller: controller,
       initialChildSize: initialChildSize,
       scrollable: scrollable,
       url: url,
       header: header,
+      headerColor: headerColor,
+      borderRadius: borderRadius,
     ),
   );
 }
@@ -38,13 +43,17 @@ class ScrollableModalBottomSheet extends StatelessWidget {
   final double initialChildSize;
   final bool scrollable;
   final String url;
+  final Color? headerColor;
+  final BorderRadiusGeometry? borderRadius;
   const ScrollableModalBottomSheet(
       {Key? key,
       required this.controller,
       this.header,
       required this.initialChildSize,
       required this.scrollable,
-      required this.url})
+      required this.url,
+      this.headerColor,
+      this.borderRadius})
       : super(key: key);
   @override
   Widget build(BuildContext context) {
@@ -54,7 +63,16 @@ class ScrollableModalBottomSheet extends StatelessWidget {
         builder: (context, scrollController) {
           return Column(
             children: [
-              if (header != null) header!,
+              if (header != null) ...{
+                Container(
+                  decoration: BoxDecoration(
+                    borderRadius: borderRadius,
+                    color: headerColor,
+                  ),
+                  height: MediaQuery.of(context).padding.bottom,
+                ),
+                header!,
+              },
               Expanded(
                   child: SingleChildScrollView(
                 physics:

--- a/lib/scrollable_modal_webview.dart
+++ b/lib/scrollable_modal_webview.dart
@@ -10,7 +10,7 @@ void showScrollableModalWebView({
   required BuildContext context,
   required WebViewController controller,
   required String url,
-  PreferredSizeWidget? header,
+  Widget? header,
   bool scrollable = true,
   double initialChildSize = 1.0,
   ShapeBorder? shape,
@@ -22,8 +22,49 @@ void showScrollableModalWebView({
     context: context,
     isScrollControlled: true,
     shape: shape,
-    builder: (BuildContext context) => const ScrollableModalWebView(),
+    builder: (BuildContext context) => ScrollableModalBottomSheet(
+      controller: controller,
+      initialChildSize: initialChildSize,
+      scrollable: scrollable,
+      url: url,
+      header: header,
+    ),
   );
+}
+
+class ScrollableModalBottomSheet extends StatelessWidget {
+  final WebViewController controller;
+  final Widget? header;
+  final double initialChildSize;
+  final bool scrollable;
+  final String url;
+  const ScrollableModalBottomSheet(
+      {Key? key,
+      required this.controller,
+      this.header,
+      required this.initialChildSize,
+      required this.scrollable,
+      required this.url})
+      : super(key: key);
+  @override
+  Widget build(BuildContext context) {
+    return DraggableScrollableSheet(
+        expand: false,
+        initialChildSize: initialChildSize,
+        builder: (context, scrollController) {
+          return Column(
+            children: [
+              if (header != null) header!,
+              Expanded(
+                  child: SingleChildScrollView(
+                physics:
+                    scrollable ? null : const NeverScrollableScrollPhysics(),
+                child: const ScrollableModalWebView(),
+              ))
+            ],
+          );
+        });
+  }
 }
 
 class ScrollableModalWebView extends StatefulWidget {


### PR DESCRIPTION
### 概要
ScrollableModalBottomSheetクラスを作成しました！
### タスク
https://www.notion.so/shu-yoshi/ScrollableModalBottomSheet-31cec3c0878f496b94ad2f0f624e3167
### 実装した内容

- example/lib/main.dartに追加 [3a1fc38](https://github.com/shinonome-inc/scrollable_modal_webview/pull/5/commits/3a1fc38c0d04e4b91aef2e955bfd310d08f0d76c)
- lib/scrollable_modal_webview.dartにScrollableModalBottomSheetクラスを追加 [bd99524](https://github.com/shinonome-inc/scrollable_modal_webview/pull/5/commits/bd9952462999eb34521586028c67bdc00e86c211)
- lib/scrollable_modal_webview.dartのshowScrollableModalWebView関数を変更 [bd99524](https://github.com/shinonome-inc/scrollable_modal_webview/pull/5/commits/bd9952462999eb34521586028c67bdc00e86c211)

### 実装後の様子
Device: iPhone 11
iOS: 16.1

https://user-images.githubusercontent.com/85224998/216220241-f1c3a48b-79ab-4e98-82fb-3608e9f38e02.mp4




### showScrollableModalWebView関数の引数headerの型をPreferedSizeWidgetからWidgetに変えた理由
ScrollableModalBottomSheetクラスにScaffold, appBarを使うと以下のような結果になる。

<img src="https://user-images.githubusercontent.com/85224998/216217970-7ac8a845-9921-4481-8f07-fe6403e0575d.png" width="300">

showModalBottomSheetにshapeを設定してもそれが反映されないことが分かる。よってScaffold, appBarを使うのをやめた。
それを修正する形でScrollableModalBottomSheetクラスを書いたのが以下のコードである。
https://github.com/shinonome-inc/scrollable_modal_webview/blob/bd9952462999eb34521586028c67bdc00e86c211/lib/scrollable_modal_webview.dart#L51-L66
また、この状態で実行すると以下のような結果が得られた。
| preferedSizeのheightが50の時 | preferedSizeのheightが100の時 | 
| ---------- | ---------- | 
| <img src="https://user-images.githubusercontent.com/85224998/216219199-bec582d9-af4e-44c0-8405-371537e60d38.png" width="300"> | <img src="https://user-images.githubusercontent.com/85224998/216219136-ae120ea8-0f05-4273-842d-6e128fadc177.png" width="300"> | 

よって、PreferedSizeのheightを変えてもそれが反映されていないことが分かる。以上より、PreferedSizeWidgetからWidgetに変更した。


