### PR TITLE
fix safeArea in ScrollableModalBottomSheet

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -47,20 +47,19 @@ class _MyHomePageState extends State<MyHomePage> {
               header: Container(
                 height: 30,
                 decoration: const BoxDecoration(
-                  borderRadius:
-                      BorderRadius.vertical(top: Radius.circular(10.0)),
                   color: Colors.blue,
                 ),
                 child: const Center(
                   child: Text('ScrollableModalBottomSheet'),
                 ),
               ),
+              backgroundColor: Colors.blue,
               controller: controller,
               initialChildSize: 1.0,
               url: 'https://flutter.dev/',
               shape: const RoundedRectangleBorder(
-                  borderRadius:
-                      BorderRadius.vertical(top: Radius.circular(10.0)))),
+                borderRadius: BorderRadius.vertical(top: Radius.circular(10.0)),
+              )),
         ),
       ),
     );

--- a/lib/scrollable_modal_webview.dart
+++ b/lib/scrollable_modal_webview.dart
@@ -57,15 +57,15 @@ class ScrollableModalBottomSheet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final double deviceHeight = MediaQuery.of(context).size.height;
-    final bool safeAreaZone = initialChildSize >=
-        1.0 * (deviceHeight - statusBarHeight) / deviceHeight;
+    final bool isSafeAreaZone =
+        initialChildSize >= (deviceHeight - statusBarHeight) / deviceHeight;
     return DraggableScrollableSheet(
         expand: false,
         initialChildSize: initialChildSize,
         builder: (context, scrollController) {
           return Column(
             children: [
-              if (safeAreaZone) SizedBox(height: statusBarHeight),
+              if (isSafeAreaZone) SizedBox(height: statusBarHeight),
               if (header != null) header!,
               Expanded(
                 child: Container(

--- a/lib/scrollable_modal_webview.dart
+++ b/lib/scrollable_modal_webview.dart
@@ -43,6 +43,8 @@ class ScrollableModalBottomSheet extends StatelessWidget {
   final bool scrollable;
   final String url;
   final double statusBarHeight;
+
+  /// this class is ui component of scrollable modal bottom sheet.
   const ScrollableModalBottomSheet({
     Key? key,
     required this.controller,

--- a/lib/scrollable_modal_webview.dart
+++ b/lib/scrollable_modal_webview.dart
@@ -14,12 +14,15 @@ void showScrollableModalWebView({
   bool scrollable = true,
   double initialChildSize = 1.0,
   ShapeBorder? shape,
+  Color? backgroundColor,
 }) {
   if (!(Platform.isIOS || Platform.isAndroid)) {
     throw Exception('This OS is not supported');
   }
+  final double statusBarHeight = MediaQuery.of(context).padding.top;
   showModalBottomSheet(
     context: context,
+    backgroundColor: backgroundColor,
     isScrollControlled: true,
     shape: shape,
     builder: (BuildContext context) => ScrollableModalBottomSheet(
@@ -28,6 +31,7 @@ void showScrollableModalWebView({
       scrollable: scrollable,
       url: url,
       header: header,
+      statusBarHeight: statusBarHeight,
     ),
   );
 }
@@ -38,6 +42,7 @@ class ScrollableModalBottomSheet extends StatelessWidget {
   final double initialChildSize;
   final bool scrollable;
   final String url;
+  final double statusBarHeight;
   const ScrollableModalBottomSheet({
     Key? key,
     required this.controller,
@@ -45,21 +50,29 @@ class ScrollableModalBottomSheet extends StatelessWidget {
     required this.initialChildSize,
     required this.scrollable,
     required this.url,
+    required this.statusBarHeight,
   }) : super(key: key);
   @override
   Widget build(BuildContext context) {
+    final double deviceHeight = MediaQuery.of(context).size.height;
     return DraggableScrollableSheet(
         expand: false,
         initialChildSize: initialChildSize,
         builder: (context, scrollController) {
           return Column(
             children: [
+              if (initialChildSize >=
+                  1.0 * (deviceHeight - statusBarHeight) / deviceHeight)
+                SizedBox(height: statusBarHeight),
               if (header != null) header!,
               Expanded(
-                  child: SingleChildScrollView(
-                physics:
-                    scrollable ? null : const NeverScrollableScrollPhysics(),
-                child: const ScrollableModalWebView(),
+                  child: Container(
+                color: Colors.white,
+                child: SingleChildScrollView(
+                  physics:
+                      scrollable ? null : const NeverScrollableScrollPhysics(),
+                  child: const ScrollableModalWebView(),
+                ),
               ))
             ],
           );

--- a/lib/scrollable_modal_webview.dart
+++ b/lib/scrollable_modal_webview.dart
@@ -57,15 +57,15 @@ class ScrollableModalBottomSheet extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     final double deviceHeight = MediaQuery.of(context).size.height;
+    final bool safeAreaZone = initialChildSize >=
+        1.0 * (deviceHeight - statusBarHeight) / deviceHeight;
     return DraggableScrollableSheet(
         expand: false,
         initialChildSize: initialChildSize,
         builder: (context, scrollController) {
           return Column(
             children: [
-              if (initialChildSize >=
-                  1.0 * (deviceHeight - statusBarHeight) / deviceHeight)
-                SizedBox(height: statusBarHeight),
+              if (safeAreaZone) SizedBox(height: statusBarHeight),
               if (header != null) header!,
               Expanded(
                 child: Container(


### PR DESCRIPTION
### 概要
ScrollableModalBottomSheetのsafeAreaを修正しました！
### タスク
https://www.notion.so/shu-yoshi/ScrollableModalBottomSheet-SafeArea-8eaf3c526ef446839d27951b5b96e4a4
### 実装内容

- showScrollableModalWebViewの引数を変更 [0163a28](https://github.com/shinonome-inc/scrollable_modal_webview/pull/7/commits/0163a28068b79900b596e7bc44983160c88d9502)
- safeAreaを追加 [b185467](https://github.com/shinonome-inc/scrollable_modal_webview/pull/7/commits/b1854674ee471d8baf2c4176fb042da04ec921bc)
- ScrollableModalBottomSheetの説明を追加 [4689d2e](https://github.com/shinonome-inc/scrollable_modal_webview/pull/7/commits/4689d2e86a033617d204901ca8821dd1a565e3e8)

### 実装後の様子
Device: iPhone 11
iOS: 16.0

<img width="300" alt="スクリーンショット 2023-02-03 16 00 56" src="https://user-images.githubusercontent.com/85224998/216533547-8fc003f0-0c3b-44ad-bf88-84b24fdc4916.png">
